### PR TITLE
Tracking eval fix: dtype and num workers

### DIFF
--- a/humenv/bench/reward_evaluation.py
+++ b/humenv/bench/reward_evaluation.py
@@ -45,13 +45,15 @@ class RewardEvaluation:
             else:
                 penv.call("set_task", task)
 
-        pbar = tqdm.tqdm(self.tasks)
+        pbar = tqdm.tqdm(self.tasks, leave=False)
         for task in pbar:
             pbar.set_description(f"task {task}")
             reset_task(task)
             local_stats = []
             for _ in range(self.num_contexts):
+                pbar.set_description(f"task {task} (inference)")
                 ctx = agent.reward_inference(task=task)
+                pbar.set_description(f"task {task} (rollout)")
                 ctx = [None] * self.num_envs if ctx is None else ctx.repeat(self.num_envs, 1)
                 st, _ = rollout(
                     penv,


### PR DESCRIPTION
## Fixes in tracking eval

1. Wrappers works now well for all Gymnasium versions.
2. Multiprocessing takes the actual workers numbers as set in `num_workers` 
3. In calculation of the tracking metrics we cast observations to float32 for compatibility with the released Meta Motivo models

## Quality of life improvements
We added and improved the tqdm progress bars